### PR TITLE
created a parser for obsidian representation of locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,8 @@ nb-configuration.xml
 ## OS X
 ##############################
 .DS_Store
+
+##############################
+## 40-Days
+##############################
+tools/obsidian_parser/output

--- a/tools/obsidian_parser/README.md
+++ b/tools/obsidian_parser/README.md
@@ -1,0 +1,11 @@
+currently, working tested definition of location is as follows:  
+  
+ file name will be name of object so no need to set it as a field.  
+"field_name_1":"field_value_1"  
+"field_name_2":"field_value_2"  
+"array_name":  
+- [[array_item_1]]
+- [[array_item_2]]
+- [[array_item_3]]
+- [[array_item_4]]
+- [[array_item_5]]

--- a/tools/obsidian_parser/main.js
+++ b/tools/obsidian_parser/main.js
@@ -1,0 +1,68 @@
+let fs = require('fs');
+fs.readdir('resources/', (err, filenames) => {
+    if (err) {
+        console.error(err)
+    }
+
+    function prepend(value, array) {
+        let newArray = array.slice();
+        newArray.unshift(value);
+        return newArray;
+    }
+
+    filenames.forEach(function (filename) {
+        if (filename.includes(".md")) {
+            fs.readFile('resources/' + filename, 'utf-8', function (err, content) {
+                if (err) {
+                    console.error(err)
+                }
+                content = content.trim()
+                let lines = content.split(/\r?\n/);
+                let result = ""
+                lines = prepend(`{"name":"${filename.replace(".md", "")}"`, lines)
+                for (let i = 1; i < lines.length; i++) {
+                    lines[i] = lines[i].replace('[[', '"')
+                    lines[i] = lines[i].replace(']]', '"')
+                    lines[i] = lines[i].replace(/([^"](":)$)/, '$1[')
+
+                    if (lines[i - 1].includes('- ') && !lines[i].includes('- ')) {
+                        lines[i - 1] = lines[i - 1] + ']'
+                    } else if (lines[i].includes('- ') && i === lines.length - 1) {
+                        lines[i] = lines[i] + ']'
+                    }
+                    lines[i] = lines[i].replace(']]', '"')
+
+                }
+                for (let i = 0; i < lines.length; i++) {
+                    lines[i] = lines[i].replace('- ', '"name":')
+
+
+                    if (i < lines.length - 1) {
+                        lines[i] = lines[i].replace(/([^"]("$))/, '$1,')
+                        if (!lines[i].includes(',')) {
+                            lines[i] = lines[i] + ','
+                            lines[i] = lines[i].replace('[,', '[')
+                        }
+                    }
+                    if (i > 0) {
+                        if (lines[i].includes('"name"')) {
+                            lines[i] = '{' + lines[i]
+                            lines[i] = lines[i].replace('",', '"},')
+                            lines[i] = lines[i].replace('"]', '"}]')
+                        }
+                    }
+
+                }
+
+                for (let i = 0; i < lines.length; i++) {
+                    result += lines[i]
+                }
+                result += '}'
+                fs.writeFileSync('output/' + filename.replace(".md", ".json"), result)
+                console.log('File added/updated: ' + filename.replace(".md", ".json"))
+            })
+        }
+
+    })
+
+})

--- a/tools/obsidian_parser/package.json
+++ b/tools/obsidian_parser/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "obsidian_parser",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/tools/obsidian_parser/resources/Babel.md
+++ b/tools/obsidian_parser/resources/Babel.md
@@ -1,0 +1,6 @@
+"type":[[Dungeon]]
+"neighbours":
+- [[Södervärn]]
+- [[Möllevången]]
+"items":
+- [[Sword]]

--- a/tools/obsidian_parser/resources/Beijers Park.md
+++ b/tools/obsidian_parser/resources/Beijers Park.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Kirseberg]]

--- a/tools/obsidian_parser/resources/Big Bowl.md
+++ b/tools/obsidian_parser/resources/Big Bowl.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Värnhem]]

--- a/tools/obsidian_parser/resources/Bulltofta Parken.md
+++ b/tools/obsidian_parser/resources/Bulltofta Parken.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Toftanäs]]

--- a/tools/obsidian_parser/resources/Caroli.md
+++ b/tools/obsidian_parser/resources/Caroli.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Gamla Stan]]

--- a/tools/obsidian_parser/resources/Dalaplan.md
+++ b/tools/obsidian_parser/resources/Dalaplan.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Södervärn]]

--- a/tools/obsidian_parser/resources/Davidshall.md
+++ b/tools/obsidian_parser/resources/Davidshall.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Triangeln]]

--- a/tools/obsidian_parser/resources/Eleda Stadion.md
+++ b/tools/obsidian_parser/resources/Eleda Stadion.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Stadionområdet]]

--- a/tools/obsidian_parser/resources/Emporia.md
+++ b/tools/obsidian_parser/resources/Emporia.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Hyllie]]

--- a/tools/obsidian_parser/resources/Entré.md
+++ b/tools/obsidian_parser/resources/Entré.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Värnhem]]

--- a/tools/obsidian_parser/resources/Folkets Park.md
+++ b/tools/obsidian_parser/resources/Folkets Park.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Möllevången]]

--- a/tools/obsidian_parser/resources/Fosie Kyrka.md
+++ b/tools/obsidian_parser/resources/Fosie Kyrka.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Fosie]]

--- a/tools/obsidian_parser/resources/Fosie.md
+++ b/tools/obsidian_parser/resources/Fosie.md
@@ -1,0 +1,8 @@
+"neighbours":
+- [[Lindängstorget]]
+- [[Fosie Kyrka]]
+- [[Heleneholms Gymnasium]]
+- [[Nydala Parken]]
+- [[Hyllie]]
+- [[Persborg]]
+- [[Södervärn]]

--- a/tools/obsidian_parser/resources/Gamla Stan.md
+++ b/tools/obsidian_parser/resources/Gamla Stan.md
@@ -1,0 +1,13 @@
+"neighbours":
+- [[Malmö C]]
+- [[Caroli]]
+- [[Lilla Torg]]
+- [[Stortorget]]
+- [[Kungsparken]]
+- [[Slottsparken]]
+- [[Gustav Adolfs Torg]]
+- [[Västra Hamnen]]
+- [[Möllevången]]
+- [[Ribbersborg]]
+- [[Värnhem]]
+- [[Triangeln]]

--- a/tools/obsidian_parser/resources/Gamla häktet.md
+++ b/tools/obsidian_parser/resources/Gamla häktet.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Kirseberg]]

--- a/tools/obsidian_parser/resources/Gustav Adolfs Torg.md
+++ b/tools/obsidian_parser/resources/Gustav Adolfs Torg.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Gamla Stan]]

--- a/tools/obsidian_parser/resources/Gyllins Trädgård.md
+++ b/tools/obsidian_parser/resources/Gyllins Trädgård.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Toftanäs]]

--- a/tools/obsidian_parser/resources/Heleneholms Gymnasium.md
+++ b/tools/obsidian_parser/resources/Heleneholms Gymnasium.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Fosie]]

--- a/tools/obsidian_parser/resources/Hyllie Station.md
+++ b/tools/obsidian_parser/resources/Hyllie Station.md
@@ -1,0 +1,5 @@
+"neighbours":
+- [[Hyllie]]
+- [[Malmö C]]
+- [[Persborgs Station]]
+- [[Station Triangeln]]

--- a/tools/obsidian_parser/resources/Hyllie.md
+++ b/tools/obsidian_parser/resources/Hyllie.md
@@ -1,0 +1,6 @@
+"neighbours":
+- [[Emporia]]
+- [[Hyllie Station]]
+- [[IKEA]]
+- [[Fosie]]
+- [[Limhamn]]

--- a/tools/obsidian_parser/resources/Hylliekrokens Golfcenter.md
+++ b/tools/obsidian_parser/resources/Hylliekrokens Golfcenter.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Ribbersborg]]

--- a/tools/obsidian_parser/resources/ICA Maxi.md
+++ b/tools/obsidian_parser/resources/ICA Maxi.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Toftanäs]]

--- a/tools/obsidian_parser/resources/IKEA.md
+++ b/tools/obsidian_parser/resources/IKEA.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Hyllie]]

--- a/tools/obsidian_parser/resources/Kalkbrottet.md
+++ b/tools/obsidian_parser/resources/Kalkbrottet.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Limhamn]]

--- a/tools/obsidian_parser/resources/Kallbadhuset.md
+++ b/tools/obsidian_parser/resources/Kallbadhuset.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Ribbersborg]]

--- a/tools/obsidian_parser/resources/Kirseberg.md
+++ b/tools/obsidian_parser/resources/Kirseberg.md
@@ -1,0 +1,7 @@
+"neighbours":
+- [[Beijers Park]]
+- [[NEWTON]]
+- [[Mässingshornet]]
+- [[Gamla häktet]]
+- [[Värnhem]]
+- [[Toftanäs]]

--- a/tools/obsidian_parser/resources/Kockum Fritid.md
+++ b/tools/obsidian_parser/resources/Kockum Fritid.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Västra Hamnen]]

--- a/tools/obsidian_parser/resources/Komvux.md
+++ b/tools/obsidian_parser/resources/Komvux.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Södervärn]]

--- a/tools/obsidian_parser/resources/Kungsparken.md
+++ b/tools/obsidian_parser/resources/Kungsparken.md
@@ -1,0 +1,3 @@
+"neighbours":
+- [[Gamla Stan]]
+- [[Slottsparken]]

--- a/tools/obsidian_parser/resources/Laserdome.md
+++ b/tools/obsidian_parser/resources/Laserdome.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Värnhem]]

--- a/tools/obsidian_parser/resources/Lilla Torg.md
+++ b/tools/obsidian_parser/resources/Lilla Torg.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Gamla Stan]]

--- a/tools/obsidian_parser/resources/Limhamn.md
+++ b/tools/obsidian_parser/resources/Limhamn.md
@@ -1,0 +1,8 @@
+"neighbours":
+- [[Kalkbrottet]]
+- [[Sibbarps Camping]]
+- [[Ön]]
+- [[Limhamns Kyrka]]
+- [[Ribbersborg]]
+- [[Stadionområdet]]
+- [[Hyllie]]

--- a/tools/obsidian_parser/resources/Limhamns Kyrka.md
+++ b/tools/obsidian_parser/resources/Limhamns Kyrka.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Limhamn]]

--- a/tools/obsidian_parser/resources/Lindängstorget.md
+++ b/tools/obsidian_parser/resources/Lindängstorget.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Fosie]]

--- a/tools/obsidian_parser/resources/Lorensborgs Torg.md
+++ b/tools/obsidian_parser/resources/Lorensborgs Torg.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Stadionområdet]]

--- a/tools/obsidian_parser/resources/Malmö C.md
+++ b/tools/obsidian_parser/resources/Malmö C.md
@@ -1,0 +1,5 @@
+"neighbours":
+- [[Gamla Stan]]
+- [[Station Triangeln]]
+- [[Persborgs Station]]
+- [[Hyllie Station]]

--- a/tools/obsidian_parser/resources/Malmö Stadion.md
+++ b/tools/obsidian_parser/resources/Malmö Stadion.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Stadionområdet]]

--- a/tools/obsidian_parser/resources/Moskén.md
+++ b/tools/obsidian_parser/resources/Moskén.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Rosengård]]

--- a/tools/obsidian_parser/resources/Musikhögskolan.md
+++ b/tools/obsidian_parser/resources/Musikhögskolan.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Persborg]]

--- a/tools/obsidian_parser/resources/Mässingshornet.md
+++ b/tools/obsidian_parser/resources/Mässingshornet.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Kirseberg]]

--- a/tools/obsidian_parser/resources/Möllevången.md
+++ b/tools/obsidian_parser/resources/Möllevången.md
@@ -1,0 +1,9 @@
+"neighbours":
+- [[Folkets Park]]
+- [[Möllevångstorget]]
+- [[Babel]]
+- [[Södervärn]]
+- [[Rosengård]]
+- [[Gamla Stan]]
+- [[Persborg]]
+- [[Triangeln]]

--- a/tools/obsidian_parser/resources/Möllevångstorget.md
+++ b/tools/obsidian_parser/resources/Möllevångstorget.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Möllevången]]

--- a/tools/obsidian_parser/resources/NEWTON.md
+++ b/tools/obsidian_parser/resources/NEWTON.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Kirseberg]]

--- a/tools/obsidian_parser/resources/Norra Grängesbergsgatan.md
+++ b/tools/obsidian_parser/resources/Norra Grängesbergsgatan.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Persborg]]

--- a/tools/obsidian_parser/resources/Nydala Parken.md
+++ b/tools/obsidian_parser/resources/Nydala Parken.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Fosie]]

--- a/tools/obsidian_parser/resources/Persborg.md
+++ b/tools/obsidian_parser/resources/Persborg.md
@@ -1,0 +1,9 @@
+"neighbours":
+- [[Persborgs Torg]]
+- [[Musikhögskolan]]
+- [[Özens Allfrukt]]
+- [[Norra Grängesbergsgatan]]
+- [[Fosie]]
+- [[Möllevången]]
+- [[Rosengård]]
+- [[Södervärn]]

--- a/tools/obsidian_parser/resources/Persborgs Station.md
+++ b/tools/obsidian_parser/resources/Persborgs Station.md
@@ -1,0 +1,5 @@
+"neighbours":
+- [[Persborg]]
+- [[Malmö C]]
+- [[Station Triangeln]]
+- [[Hyllie Station]]

--- a/tools/obsidian_parser/resources/Persborgs Torg.md
+++ b/tools/obsidian_parser/resources/Persborgs Torg.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Persborg]]

--- a/tools/obsidian_parser/resources/Pildammsparken.md
+++ b/tools/obsidian_parser/resources/Pildammsparken.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Stadionområdet]]

--- a/tools/obsidian_parser/resources/Ribbersborg.md
+++ b/tools/obsidian_parser/resources/Ribbersborg.md
@@ -1,0 +1,8 @@
+"neighbours":
+- [[Ribbersborgsstranden]]
+- [[Hylliekrokens Golfcenter]]
+- [[Kallbadhuset]]
+- [[Limhamn]]
+- [[Gamla Stan]]
+- [[Västra Hamnen]]
+- [[Stadionområdet]]

--- a/tools/obsidian_parser/resources/Ribbersborgsstranden.md
+++ b/tools/obsidian_parser/resources/Ribbersborgsstranden.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Ribbersborg]]

--- a/tools/obsidian_parser/resources/Risebergaskolan.md
+++ b/tools/obsidian_parser/resources/Risebergaskolan.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Toftanäs]]

--- a/tools/obsidian_parser/resources/Rosengård Centrum.md
+++ b/tools/obsidian_parser/resources/Rosengård Centrum.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Rosengård]]

--- a/tools/obsidian_parser/resources/Rosengård.md
+++ b/tools/obsidian_parser/resources/Rosengård.md
@@ -1,0 +1,8 @@
+"neighbours":
+- [[Rosengård Centrum]]
+- [[Moskén]]
+- [[Östra Kyrkogården]]
+- [[Rosengårdsbadet]]
+- [[Möllevången]]
+- [[Persborg]]
+- [[Toftanäs]]

--- a/tools/obsidian_parser/resources/Rosengårdsbadet.md
+++ b/tools/obsidian_parser/resources/Rosengårdsbadet.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Rosengård]]

--- a/tools/obsidian_parser/resources/Scania Badet.md
+++ b/tools/obsidian_parser/resources/Scania Badet.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Västra Hamnen]]

--- a/tools/obsidian_parser/resources/Sibbarps Camping.md
+++ b/tools/obsidian_parser/resources/Sibbarps Camping.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Limhamn]]

--- a/tools/obsidian_parser/resources/Sjukhuset.md
+++ b/tools/obsidian_parser/resources/Sjukhuset.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Södervärn]]

--- a/tools/obsidian_parser/resources/Slottsparken.md
+++ b/tools/obsidian_parser/resources/Slottsparken.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Kungsparken]]

--- a/tools/obsidian_parser/resources/St Johannes Kyrka.md
+++ b/tools/obsidian_parser/resources/St Johannes Kyrka.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Triangeln]]

--- a/tools/obsidian_parser/resources/Stadionområdet.md
+++ b/tools/obsidian_parser/resources/Stadionområdet.md
@@ -1,0 +1,8 @@
+"neighbours":
+- [[Pildammsparken]]
+- [[Malmö Stadion]]
+- [[Eleda Stadion]]
+- [[Lorensborgs Torg]]
+- [[Södervärn]]
+- [[Limhamn]]
+- [[Ribbersborg]]

--- a/tools/obsidian_parser/resources/Stapelbäddsparken.md
+++ b/tools/obsidian_parser/resources/Stapelbäddsparken.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Västra Hamnen]]

--- a/tools/obsidian_parser/resources/Station Triangeln.md
+++ b/tools/obsidian_parser/resources/Station Triangeln.md
@@ -1,0 +1,5 @@
+"neighbours":
+- [[Triangeln]]
+- [[Malmö C]]
+- [[Persborgs Station]]
+- [[Hyllie Station]]

--- a/tools/obsidian_parser/resources/Stortorget.md
+++ b/tools/obsidian_parser/resources/Stortorget.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Gamla Stan]]

--- a/tools/obsidian_parser/resources/Södervärn.md
+++ b/tools/obsidian_parser/resources/Södervärn.md
@@ -1,0 +1,8 @@
+"neighbours":
+- [[Dalaplan]]
+- [[Komvux]]
+- [[Sjukhuset]]
+- [[Möllevången]]
+- [[Stadionområdet]]
+- [[Fosie]]
+- [[Persborg]]

--- a/tools/obsidian_parser/resources/Toftanäs.md
+++ b/tools/obsidian_parser/resources/Toftanäs.md
@@ -1,0 +1,7 @@
+"neighbours":
+- [[ICA Maxi]]
+- [[Risebergaskolan]]
+- [[Gyllins Trädgård]]
+- [[Bulltofta Parken]]
+- [[Kirseberg]]
+- [[Rosengård]]

--- a/tools/obsidian_parser/resources/Triangeln.md
+++ b/tools/obsidian_parser/resources/Triangeln.md
@@ -1,0 +1,9 @@
+"neighbours":
+- [[Triangelns Köpcenter]]
+- [[Station Triangeln]]
+- [[Davidshall]]
+- [[St Johannes Kyrka]]
+- [[Gamla Stan]]
+- [[Möllevången]]
+
+

--- a/tools/obsidian_parser/resources/Triangelns Köpcenter.md
+++ b/tools/obsidian_parser/resources/Triangelns Köpcenter.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Triangeln]]

--- a/tools/obsidian_parser/resources/Turning Torso.md
+++ b/tools/obsidian_parser/resources/Turning Torso.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Västra Hamnen]]

--- a/tools/obsidian_parser/resources/Värnhem.md
+++ b/tools/obsidian_parser/resources/Värnhem.md
@@ -1,0 +1,7 @@
+"neighbours":
+- [[Entré]]
+- [[Värnhemstorget]]
+- [[Laserdome]]
+- [[Big Bowl]]
+- [[Kirseberg]]
+- [[Gamla Stan]]

--- a/tools/obsidian_parser/resources/Värnhemstorget.md
+++ b/tools/obsidian_parser/resources/Värnhemstorget.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Värnhem]]

--- a/tools/obsidian_parser/resources/Västra Hamnen.md
+++ b/tools/obsidian_parser/resources/Västra Hamnen.md
@@ -1,0 +1,7 @@
+"neighbours":
+- [[Turning Torso]]
+- [[Kockum Fritid]]
+- [[Scania Badet]]
+- [[Stapelbäddsparken]]
+- [[Gamla Stan]]
+- [[Ribbersborg]]

--- a/tools/obsidian_parser/resources/Ön.md
+++ b/tools/obsidian_parser/resources/Ön.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Limhamn]]

--- a/tools/obsidian_parser/resources/Östra Kyrkogården.md
+++ b/tools/obsidian_parser/resources/Östra Kyrkogården.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Rosengård]]

--- a/tools/obsidian_parser/resources/Özens Allfrukt.md
+++ b/tools/obsidian_parser/resources/Özens Allfrukt.md
@@ -1,0 +1,2 @@
+"neighbours":
+- [[Persborg]]


### PR DESCRIPTION
parses markdown in specific format into json structure for game world generators. should work for other configurations as well, must test. note, objects inside of an arrray have only been tested with name, and should by design only contain a name, as they will serve as references to run generators for their specific types with their names as input. lazy fix i know, but there are more important things to prioritize.